### PR TITLE
Explicitly specify utf8 encoding

### DIFF
--- a/core/extractor.py
+++ b/core/extractor.py
@@ -20,7 +20,7 @@ class StringLiteralExtractor:
         return self
 
     def dump(self, output_path):
-        with open(output_path, "w") as f:
+        with open(output_path, "w", encoding="utf-8") as f:
             f.write(json.dumps(self.to_dict(), indent=2, ensure_ascii=False))
 
     def _extract(self, f):

--- a/core/patcher.py
+++ b/core/patcher.py
@@ -16,7 +16,7 @@ class StringLiteralPatcher:
         self.extractor.extract()
 
     def update(self):
-        with open(self.stringliteral_filepath, "r") as f:
+        with open(self.stringliteral_filepath, "r", encoding="utf-8") as f:
             self._populate_patched_stringliterals(f)
         self._update_extractor_data()
         return self


### PR DESCRIPTION
I ran into a problem trying to run the script on Windows to edit strings in a Japanese game, namely that `open()` without an encoding explicitly specified defaults to the Windows default encoding cp1252 and should the metadata contain symbols that cannot be correctly represented in this encoding, the script will simply fail with an error like

```
Traceback (most recent call last):
  File "C:\repos\il2cpp-stringliteral-patcher\extract.py", line 20, in <module>
    extractor.extract().dump(args.output)
  File "C:\repos\il2cpp-stringliteral-patcher\core\extractor.py", line 24, in dump
    f.write(json.dumps(self.to_dict(), indent=2, ensure_ascii=False))
  File "C:\Program Files\Python311\Lib\encodings\cp1252.py", line 19, in encode
    return codecs.charmap_encode(input,self.errors,encoding_table)[0]
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
UnicodeEncodeError: 'charmap' codec can't encode character '\ufff7' in position 282: character maps to <undefined>
```

Adding explicit `encoding="utf-8"` to both the patcher and extractor scripts makes sure the json file is written and read as utf8 eliminating this issue and letting the script be run correctly on Windows without any further configuration. I tested it quickly with the game using Japanese text and after these edits the script was able to edit the metadata strings without issues, so it _Works on my machine™_ as far as I'm aware.